### PR TITLE
Add `constraints` schema

### DIFF
--- a/app/Option.php
+++ b/app/Option.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Syntatis\WP\Option;
 
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Syntatis\WP\Hook\Hook;
 use Syntatis\WP\Option\Support\InputSanitizer;
 use Syntatis\WP\Option\Support\InputValidator;
@@ -13,7 +15,8 @@ use function array_merge;
 
 /**
  * @phpstan-type OptionType 'array'|'boolean'|'float'|'integer'|'string'
- * @phpstan-type OptionSchema array{type: OptionType, default?: mixed, priority?: int, constraints?: array<callable>|callable}
+ * @phpstan-type OptionConstraints callable|array<callable>|Constraint|ValidatorInterface|null
+ * @phpstan-type OptionSchema array{type: OptionType, default?: mixed, priority?: int, constraints?: OptionConstraints}
  */
 class Option
 {

--- a/app/SiteOption.php
+++ b/app/SiteOption.php
@@ -73,7 +73,7 @@ class SiteOption
 			$optionPriority = $schema['priority'] ?? $this->priority;
 
 			$inputSanitizer = new InputSanitizer();
-			$inputValidator = new InputValidator($optionType);
+			$inputValidator = new InputValidator($optionType, $schema['constraints'] ?? []);
 			$outputResolver = new OutputResolver($optionType, $this->strict);
 
 			$this->hook->addFilter('pre_add_site_option_' . $optionName, function ($value) use ($optionName, $inputSanitizer, $inputValidator) {

--- a/app/Support/InputValidator.php
+++ b/app/Support/InputValidator.php
@@ -11,7 +11,6 @@ use Syntatis\WP\Option\Option;
 use TypeError;
 
 use function array_key_exists;
-use function count;
 use function gettype;
 use function is_array;
 use function is_bool;

--- a/app/Support/InputValidator.php
+++ b/app/Support/InputValidator.php
@@ -112,7 +112,7 @@ class InputValidator
 			}
 
 			foreach ($validator as $v) {
-				throw new InvalidArgumentException((string) $v);
+				throw new InvalidArgumentException((string) $v->getMessage());
 			}
 		}
 	}

--- a/app/Support/InputValidator.php
+++ b/app/Support/InputValidator.php
@@ -105,14 +105,10 @@ class InputValidator
 				continue;
 			}
 
-			$validator = Validator::instance()->validate($value, $constraint);
+			$validators = Validator::instance()->validate($value, $constraint);
 
-			if (count($validator) <= 0) {
-				continue;
-			}
-
-			foreach ($validator as $v) {
-				throw new InvalidArgumentException((string) $v->getMessage());
+			foreach ($validators as $validator) {
+				throw new InvalidArgumentException((string) $validator->getMessage());
 			}
 		}
 	}

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
 	},
 	"require": {
 		"php": ">=7.4",
+		"syntatis/utils": "^1.0",
 		"syntatis/wp-hook": "^1.0"
 	},
 	"require-dev": {
@@ -38,7 +39,6 @@
 		"roots/wordpress": "^6.4",
 		"symfony/var-dumper": "^5.4",
 		"syntatis/coding-standard": "^1.0",
-		"syntatis/utils": "^1.0",
 		"szepeviktor/phpstan-wordpress": "^1.3",
 		"wp-phpunit/wp-phpunit": "^6.4",
 		"yoast/phpunit-polyfills": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		}
 	},
 	"require": {
-		"php": "^7.4 || ^8.0",
+		"php": ">=7.4",
 		"syntatis/wp-hook": "^1.0"
 	},
 	"require-dev": {
@@ -38,6 +38,7 @@
 		"roots/wordpress": "^6.4",
 		"symfony/var-dumper": "^5.4",
 		"syntatis/coding-standard": "^1.0",
+		"syntatis/utils": "^1.0",
 		"szepeviktor/phpstan-wordpress": "^1.3",
 		"wp-phpunit/wp-phpunit": "^6.4",
 		"yoast/phpunit-polyfills": "^2.0"

--- a/tests/OptionTest.php
+++ b/tests/OptionTest.php
@@ -1291,6 +1291,32 @@ class OptionTest extends TestCase
 		update_option($this->optionName, $value);
 	}
 
+	/**
+	 * @dataProvider dataConstraints
+	 *
+	 * @param mixed $constraints The constraints to be passed in the schema.
+	 * @param mixed $value       The value to add in the option.
+	 */
+	public function testUpdateConstraintsNonStrict($constraints, $value): void
+	{
+		add_option($this->optionName, ['__syntatis' => 'email@example.org']);
+
+		$option = new Option($this->hook);
+		$option->setSchema([
+			$this->optionName => [
+				'type' => 'string',
+				'constraints' => $constraints,
+			],
+		]);
+		$option->register();
+
+		$this->assertSame('email@example.org', get_option($this->optionName));
+
+		update_option($this->optionName, $value);
+
+		$this->assertSame($value, get_option($this->optionName));
+	}
+
 	public function dataConstraints(): iterable
 	{
 		yield ['\Syntatis\Utils\is_email', 'Maybe Email', 'Value does not match the given constraints.'];

--- a/tests/SiteOptionTest.php
+++ b/tests/SiteOptionTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Syntatis\WP\Option\Tests;
 
+use InvalidArgumentException;
+use Symfony\Component\Validator\Constraints as Assert;
 use Syntatis\WP\Hook\Hook;
 use Syntatis\WP\Option\SiteOption;
 use TypeError;
@@ -916,5 +918,114 @@ class SiteOptionTest extends TestCase
 		yield [['foo' => 'bar'], ['foo' => 'bar']];
 
 		yield [null, null];
+	}
+
+	/**
+	 * @dataProvider dataConstraints
+	 * @group strict-mode
+	 *
+	 * @param mixed $constraints  The constraints to be passed in the schema.
+	 * @param mixed $value        The value to add in the option.
+	 * @param mixed $errorMessage The expected error message.
+	 */
+	public function testAddConstraints($constraints, $value, $errorMessage): void
+	{
+		$option = new SiteOption($this->hook, null, 1);
+		$option->setSchema([
+			$this->optionName => [
+				'type' => 'string',
+				'constraints' => $constraints,
+			],
+		]);
+		$option->register();
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage($errorMessage);
+
+		add_site_option($this->optionName, $value);
+	}
+
+	/**
+	 * @dataProvider dataConstraints
+	 *
+	 * @param mixed $constraints The constraints to be passed in the schema.
+	 * @param mixed $value       The value to add in the option.
+	 */
+	public function testAddConstraintsNonStrict($constraints, $value): void
+	{
+		$option = new SiteOption($this->hook);
+		$option->setSchema([
+			$this->optionName => [
+				'type' => 'string',
+				'constraints' => $constraints,
+			],
+		]);
+		$option->register();
+
+		$this->assertTrue(add_site_option($this->optionName, $value));
+		$this->assertSame($value, get_site_option($this->optionName));
+	}
+
+	/**
+	 * @dataProvider dataConstraints
+	 * @group strict-mode
+	 *
+	 * @param mixed $constraints  The constraints to be passed in the schema.
+	 * @param mixed $value        The value to add in the option.
+	 * @param mixed $errorMessage The expected error message.
+	 */
+	public function testUpdateConstraints($constraints, $value, $errorMessage): void
+	{
+		add_site_option($this->optionName, ['__syntatis' => 'email@example.org']);
+
+		$option = new SiteOption($this->hook, null, 1);
+		$option->setSchema([
+			$this->optionName => [
+				'type' => 'string',
+				'constraints' => $constraints,
+			],
+		]);
+		$option->register();
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage($errorMessage);
+
+		update_site_option($this->optionName, $value);
+	}
+
+	/**
+	 * @dataProvider dataConstraints
+	 *
+	 * @param mixed $constraints The constraints to be passed in the schema.
+	 * @param mixed $value       The value to add in the option.
+	 */
+	public function testUpdateConstraintsNonStrict($constraints, $value): void
+	{
+		add_site_option($this->optionName, ['__syntatis' => 'email@example.org']);
+
+		$option = new SiteOption($this->hook);
+		$option->setSchema([
+			$this->optionName => [
+				'type' => 'string',
+				'constraints' => $constraints,
+			],
+		]);
+		$option->register();
+
+		$this->assertSame('email@example.org', get_site_option($this->optionName));
+
+		update_site_option($this->optionName, $value);
+
+		$this->assertSame($value, get_site_option($this->optionName));
+	}
+
+	public function dataConstraints(): iterable
+	{
+		yield ['\Syntatis\Utils\is_email', 'Maybe Email', 'Value does not match the given constraints.'];
+		yield [new Assert\Email(null, 'The email {{ value }} is not a valid email.'), 'Hello Email', 'The email "Hello Email" is not a valid email.'];
+
+		// With arrays.
+		yield [['\Syntatis\Utils\is_email'], 'Maybe Email', 'Value does not match the given constraints.'];
+		yield [[new Assert\Email(null, 'The email {{ value }} is not a valid email.')], 'Hello Email', 'The email "Hello Email" is not a valid email.'];
 	}
 }

--- a/tests/Support/InputValidatorTest.php
+++ b/tests/Support/InputValidatorTest.php
@@ -73,6 +73,21 @@ class InputValidatorTest extends TestCase
 		$validator->validate($value);
 	}
 
+	/**
+	 * @dataProvider dataInvalidConstraints
+	 *
+	 * @param string                                                $type        The type of the value to validate.
+	 * @param callable|array<callable>|Constraint|array<Constraint> $constraints List of constraints to validate against.
+	 * @param mixed                                                 $value       The value to validate.
+	 */
+	public function testInvalidConstraints(string $type, $constraints, $value): void
+	{
+		$this->expectNotToPerformAssertions();
+
+		$validator = new InputValidator($type, $constraints);
+		$validator->validate($value);
+	}
+
 	public function dataValidateInvalidValueType(): iterable
 	{
 		yield ['string', true, 'boolean'];
@@ -114,5 +129,15 @@ class InputValidatorTest extends TestCase
 		// With arrays.
 		yield ['string', ['\Syntatis\Utils\is_email'], 'Maybe Email', 'Value does not match the given constraints.'];
 		yield ['string', [new Assert\Email(null, 'The email {{ value }} is not a valid email.')], 'Hello Email', 'The email "Hello Email" is not a valid email.'];
+	}
+
+	public function dataInvalidConstraints(): iterable
+	{
+		yield ['string', '\Syntatis\Utils\is_emails', 'Hello world!'];
+		yield ['string', false, 'Hello world!'];
+		yield ['string', '', 'Hello world!'];
+		yield ['string', ['\Syntatis\Utils\is_emails'], 'Hello world!'];
+		yield ['string', [''], 'Hello world!'];
+		yield ['string', [false], 'Hello world!'];
 	}
 }


### PR DESCRIPTION
This Pull Request introduces a feature that allows users to include an additional validation function when adding a value to the option beyond just validating the value type. The function may, for example, validate whether a particular value conforms to a specified pattern. Users can now integrate this validation function by including it in the `constraints` within the schema.

```php
$option = new Option($this->hook, null, 1);
$option->setSchema([
   'foo' => [
      'type' => 'string',
      'constraints' => 'is_email',
   ],
]);
$option->register();

add_option('foo', 'not email'); // Will throw an Exception.
```

This enables users to enhance validation for specific values, giving greater flexibility and control.